### PR TITLE
Add 26 Internet Archive embeds organized by channel

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,16 +399,24 @@
     <section id="archive">
       <div class="section-title">
         <h3>Internet Archive Classic</h3>
-        <span class="tag">Press play</span>
+        <span class="tag">Press play • Free culture forever</span>
       </div>
 
-      <!-- 1 -->
+      <!-- BOOB TUBE: MTV / Beavis & Butthead -->
+      <div class="section-title" style="margin-top:28px;">
+        <h3>📺 Boob Tube (MTV Classics)</h3>
+        <span class="tag">Uncensored • No sign-ups</span>
+      </div>
+
       <article class="card">
-        <h4>106 It’s Sports (2019-11)</h4>
-        <div class="player" style="--r:560/384">
+        <h4>Beavis and Butthead - King Turd Collection (Complete Series 1993-1997)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Every episode uncensored as originally aired on MTV. All music videos, banned episodes, Christmas special, Butt Bowl I & II, and "Do America" movie with deleted scenes.
+        </p>
+        <div class="player">
           <iframe
-            src="https://archive.org/embed/106itssports_201911"
-            title="Internet Archive — 106 It's Sports (2019-11)"
+            src="https://archive.org/embed/beavis-and-butthead-king-turd-collection"
+            title="Internet Archive — Beavis and Butthead King Turd Collection"
             loading="lazy"
             allow="fullscreen"
             allowfullscreen
@@ -417,12 +425,127 @@
           ></iframe>
         </div>
         <div class="row">
-          <span class="muted">Tip: fullscreen works best on the embed’s own player controls.</span>
-          <a class="btn secondary" href="https://archive.org/details/106itssports_201911" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+          <span class="muted">The complete uncensored collection. Heh heh heh.</span>
+          <a class="btn secondary" href="https://archive.org/details/beavis-and-butthead-king-turd-collection" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
         </div>
       </article>
 
-      <!-- 2 -->
+      <article class="card">
+        <h4>MTV 4 Hours of Music Videos & Beavis and Butt-Head (July 1993)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Time capsule of early MTV: 4-hour block with music videos and Beavis & Butt-Head episodes, plus a full Home Improvement episode.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/mtv-4-hours-of-music-videos-and-beavis-and-butt-head-july-1993-full-episode-of-h"
+            title="Internet Archive — MTV 4 Hours July 1993"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Authentic MTV experience from 1993.</span>
+          <a class="btn secondary" href="https://archive.org/details/mtv-4-hours-of-music-videos-and-beavis-and-butt-head-july-1993-full-episode-of-h" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>Beavis And Butthead MTV Moronathon</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Hours of Beavis and Butthead marathon followed by Liquid Television and other MTV programming.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/beavis-and-butthead-mtv-moronathon"
+            title="Internet Archive — Beavis MTV Moronathon"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Marathon viewing at its finest.</span>
+          <a class="btn secondary" href="https://archive.org/details/beavis-and-butthead-mtv-moronathon" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>Beavis & Butt-Head: Butt Bowl I (January 30, 1994)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Super Bowl counter-programming special event. MTV's answer to the big game.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/butt-bowl-i"
+            title="Internet Archive — Butt Bowl I"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">The real Super Bowl.</span>
+          <a class="btn secondary" href="https://archive.org/details/butt-bowl-i" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <!-- CHRISTMAS CLASSICS -->
+      <div class="section-title" style="margin-top:28px;">
+        <h3>🎄 Christmas Classics</h3>
+        <span class="tag">Holiday nostalgia</span>
+      </div>
+
+      <article class="card">
+        <h4>1980s Christmas Television Commercials Archive (500+ Commercials, 4 Hours)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          The crown jewel: almost 500 individual Christmas commercials from the 1980s. Includes Coca-Cola ads, mall Santa commercials, toy ads, and retail commercials. No repeats.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/80sChristmasCommercials"
+            title="Internet Archive — 1980s Christmas Commercials"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">4 hours of pure Christmas nostalgia.</span>
+          <a class="btn secondary" href="https://archive.org/details/80sChristmasCommercials" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>80's Christmas Specials With Commercials</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          A Garfield Christmas, Claymation Christmas Carol, Sesame Street On Ice, and Bugs Bunny's Looney Christmas Tales — all with original commercials intact.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/80s-christmas-specials-with-commercials"
+            title="Internet Archive — 80s Christmas Specials"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Perfect VHS time capsule.</span>
+          <a class="btn secondary" href="https://archive.org/details/80s-christmas-specials-with-commercials" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
       <article class="card">
         <h4>Ernest Saves Christmas (1993-12-11)</h4>
         <div class="player">
@@ -437,12 +560,11 @@
           ></iframe>
         </div>
         <div class="row">
-          <span class="muted">If it doesn’t fill the box, check the CSS for .player iframe.</span>
+          <span class="muted">Ernest does it again.</span>
           <a class="btn secondary" href="https://archive.org/details/Ernest_Saves_Christmas_ABC_WOC_1993-12-11" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
         </div>
       </article>
 
-      <!-- 3 (placeholder example you can swap) -->
       <article class="card">
         <h4>The Miracle on 34th Street</h4>
         <div class="player">
@@ -457,8 +579,419 @@
           ></iframe>
         </div>
         <div class="row">
-          <span class="muted">Swap the embed slug above to whatever item you want.</span>
+          <span class="muted">The classic Christmas film.</span>
           <a class="btn secondary" href="https://archive.org/details/TheMiracleon34thStreet" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>A Very Special Christmas With Beavis And Butthead (1995)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Rare 1995 Christmas special that hasn't been officially released due to licensing issues. TV rip preserved for posterity.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/a-very-special-christmas-with-beavis-and-butthead-TVRiP"
+            title="Internet Archive — Beavis Christmas Special 1995"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Never officially released. Here it is anyway.</span>
+          <a class="btn secondary" href="https://archive.org/details/a-very-special-christmas-with-beavis-and-butthead-TVRiP" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>Retro 80s Christmas Toy Commercials (1985)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Christmas toy commercials from 1985 including Transformers, She-Ra, and other classic 80s toys. Peak holiday advertising nostalgia.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/she-ra-1985-christmas-commercials"
+            title="Internet Archive — 1985 Christmas Toy Ads"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Every kid's dream Christmas list.</span>
+          <a class="btn secondary" href="https://archive.org/details/she-ra-1985-christmas-commercials" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>Holidays Are Coming - Coca-Cola Christmas Commercial</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          The iconic "Holidays Are Coming" Coca-Cola commercial featuring the illuminated truck convoy. One of the most recognizable holiday ads of all time.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/CocaColaChristmas"
+            title="Internet Archive — Coca-Cola Christmas Commercial"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">You know Christmas is coming when you see this.</span>
+          <a class="btn secondary" href="https://archive.org/details/CocaColaChristmas" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>MTV Christmas Promos (1985)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          MTV Christmas promotional bumpers and segments from 1985. Vintage MTV holiday vibes with that distinctive 80s aesthetic.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/christmas-promo-mtv-1985"
+            title="Internet Archive — MTV Christmas 1985"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">MTV doing Christmas right.</span>
+          <a class="btn secondary" href="https://archive.org/details/christmas-promo-mtv-1985" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <!-- VINTAGE COMMERCIALS -->
+      <div class="section-title" style="margin-top:28px;">
+        <h3>📻 Vintage Commercials (Free Branding for the Legends)</h3>
+        <span class="tag">Respect to the creators</span>
+      </div>
+
+      <article class="card">
+        <h4>Vintage Commercials - 1980s/1990s Saturday Morning Cartoons</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Commercial breaks from CBS Garfield and Friends (1993-4) and Family Channel Super Mario Bros Super Show (1993). Includes Nintendo, McDonald's, and toys.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/Vintage_Commercials_Advertisements_80s"
+            title="Internet Archive — Saturday Morning Commercials"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Saturday morning nostalgia.</span>
+          <a class="btn secondary" href="https://archive.org/details/Vintage_Commercials_Advertisements_80s" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>25 Years of McDonald's Commercials (1963-1992)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Official McDonald's compilation from 1992 featuring commercials spanning 1963-1992, plus McDonaldland bloopers.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/McDonaldsCommercials2"
+            title="Internet Archive — 25 Years of McDonald's"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Free branding for the Golden Arches.</span>
+          <a class="btn secondary" href="https://archive.org/details/McDonaldsCommercials2" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>80s, 90s, 2000s Commercial Compilation</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Mix of kid and adult commercials spanning three decades. VHS quality nostalgia.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/80s-2000s-commercial-compilation"
+            title="Internet Archive — 80s/90s/2000s Commercials"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Three decades of advertising gold.</span>
+          <a class="btn secondary" href="https://archive.org/details/80s-2000s-commercial-compilation" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>80s/90s Toy Commercial Compilation</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Nostalgic toy commercials from the 80s and 90s including Transformers and more. Upscaled to 720p.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/80s-90s-toy-commercial-compilation-nostalgia-720p"
+            title="Internet Archive — 80s/90s Toy Commercials"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Every toy you begged your parents for.</span>
+          <a class="btn secondary" href="https://archive.org/details/80s-90s-toy-commercial-compilation-nostalgia-720p" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>Late 80s/Early 90s Commercials & Bumpers</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Authentic commercials and network bumpers from late 80s/early 90s VHS tapes.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/commercialpack1"
+            title="Internet Archive — Late 80s/Early 90s Commercials"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Network bumper nostalgia.</span>
+          <a class="btn secondary" href="https://archive.org/details/commercialpack1" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <!-- SATURDAY MARATHONS / PBS -->
+      <div class="section-title" style="margin-top:28px;">
+        <h3>📡 Saturday Marathons & Local TV</h3>
+        <span class="tag">Public broadcasting nostalgia</span>
+      </div>
+
+      <article class="card">
+        <h4>WOR-TV Channel 9 - 1980s Movie Archive (NYC)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Famous programming blocks including "Fright Night," "Four O'Clock Movie," and "9 in the Afternoon" from New York's WOR-TV.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/wor-tv-and-rko-general-1980s-movie-archive-and-graphics"
+            title="Internet Archive — WOR-TV Movie Archive"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Classic NYC local TV movie blocks.</span>
+          <a class="btn secondary" href="https://archive.org/details/wor-tv-and-rko-general-1980s-movie-archive-and-graphics" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>ABC Saturday Morning Cartoons (December 19, 1981)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          2-hour block of ABC Saturday morning cartoons and commercials from December 1981. Authentic Saturday morning marathon experience.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/vts-01-1_20200929"
+            title="Internet Archive — ABC Saturday Morning 1981"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Saturday morning in 1981.</span>
+          <a class="btn secondary" href="https://archive.org/details/vts-01-1_20200929" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>106 It's Sports (2019-11)</h4>
+        <div class="player" style="--r:560/384">
+          <iframe
+            src="https://archive.org/embed/106itssports_201911"
+            title="Internet Archive — 106 It's Sports (2019-11)"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Sports commentary from the archives.</span>
+          <a class="btn secondary" href="https://archive.org/details/106itssports_201911" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>KSCH-58 Saturday Afternoon Movie (Sacramento, 1988)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Saturday Afternoon Movie bumpers and commercials from November 5, 1988. Authentic local TV station programming.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/capture-a-4644"
+            title="Internet Archive — KSCH Saturday Movie 1988"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Saturday afternoon in Sacramento.</span>
+          <a class="btn secondary" href="https://archive.org/details/capture-a-4644" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>PBS (KTCA) Programming (Minneapolis, 1994)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Content aired on PBS station KTCA-TV during "Victor Borge II: Then and Now" special in 1994.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/KTCAVideo"
+            title="Internet Archive — PBS KTCA 1994"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Local PBS vibes from the 90s.</span>
+          <a class="btn secondary" href="https://archive.org/details/KTCAVideo" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>Manhattan Cable TV Picture Classifieds (Early 80s)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Approximately 12 minutes of Manhattan Cable TV Picture Classifieds from around midnight in early April, early 1980s. Rotating classified ads for restaurants, psychic services, VCR repair, health clubs.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/manhattan-public-access-edited"
+            title="Internet Archive — Manhattan Cable Classifieds"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Midnight in Manhattan, early 80s.</span>
+          <a class="btn secondary" href="https://archive.org/details/manhattan-public-access-edited" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <!-- STATIC / TV NOISE (For the vibe) -->
+      <div class="section-title" style="margin-top:28px;">
+        <h3>📺 TV Static & Test Patterns (For The Vibe)</h3>
+        <span class="tag">Channel transitions</span>
+      </div>
+
+      <article class="card">
+        <h4>TV Static Noise (20 seconds)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Clean TV static/noise stock footage, perfect for transitions and that authentic TV vibe.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/Static_Noise_Video"
+            title="Internet Archive — TV Static"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">The sound of childhood.</span>
+          <a class="btn secondary" href="https://archive.org/details/Static_Noise_Video" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>VHS Glitches and Static Noise (24 seconds with audio)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Old TV static noise with VHS glitch effects, includes authentic sound.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/youtube-lftoMfTNRM4"
+            title="Internet Archive — VHS Glitches"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">Authentic VHS tracking issues.</span>
+          <a class="btn secondary" href="https://archive.org/details/youtube-lftoMfTNRM4" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h4>ABC TV Test Pattern (Early 80s)</h4>
+        <p style="margin:8px 0; color:var(--mut); line-height:1.45;">
+          Real Australian Broadcasting Corporation test pattern from early 1980s with period music.
+        </p>
+        <div class="player">
+          <iframe
+            src="https://archive.org/embed/ABCTest_1980s"
+            title="Internet Archive — ABC Test Pattern 1980s"
+            loading="lazy"
+            allow="fullscreen"
+            allowfullscreen
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+          ></iframe>
+        </div>
+        <div class="row">
+          <span class="muted">When the station signed off for the night.</span>
+          <a class="btn secondary" href="https://archive.org/details/ABCTest_1980s" target="_blank" rel="noopener noreferrer">Open on Archive.org</a>
         </div>
       </article>
     </section>


### PR DESCRIPTION
Expanded the archive section with curated content from Internet Archive:

📺 Boob Tube (MTV Classics):
- Beavis & Butthead complete series (King Turd Collection)
- MTV 4-hour marathon blocks
- Butt Bowl I special event

🎄 Christmas Classics:
- 500+ vintage Christmas commercials (4 hours)
- 80s Christmas specials with original commercials
- Rare Beavis Christmas special
- Coca-Cola, toy ads, MTV holiday content

📻 Vintage Commercials:
- Saturday morning cartoon commercials
- 25 years of McDonald's ads
- 80s/90s toy commercials
- Network bumpers and promos

📡 Saturday Marathons & Local TV:
- WOR-TV NYC movie blocks
- ABC Saturday morning cartoons
- PBS programming
- Local public access content

📺 TV Static & Test Patterns:
- Authentic TV static/VHS glitches
- ABC test pattern from early 80s

All content preserves free culture, respects creators, and provides
nostalgia without barriers. No sign-ups, no tracking, just pure archives.

Built from iPhone by Jacques. SPRAXXX Nation rising. 🔥